### PR TITLE
Refactor: Rename module to GitHub URL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module payment-ms
+module github.com/eralves01/payment-ms
 
 go 1.24.1
 

--- a/handlers/payment_handler.go
+++ b/handlers/payment_handler.go
@@ -3,10 +3,11 @@ package handlers
 import (
 	"fmt"
 	"net/http"
-	"payment-ms/processors"
-	"payment-ms/services"
 
-	"payment-ms/models"
+	"github.com/eralves01/payment-ms/processors"
+	"github.com/eralves01/payment-ms/services"
+
+	"github.com/eralves01/payment-ms/models"
 
 	"github.com/gorilla/mux"
 )

--- a/handlers/user_handler.go
+++ b/handlers/user_handler.go
@@ -4,9 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"payment-ms/models"
-	"payment-ms/services"
 	"time"
+
+	"github.com/eralves01/payment-ms/models"
+	"github.com/eralves01/payment-ms/services"
 
 	"github.com/gorilla/mux"
 )

--- a/main.go
+++ b/main.go
@@ -5,9 +5,10 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"payment-ms/configs"
-	"payment-ms/database"
-	"payment-ms/routes"
+
+	"github.com/eralves01/payment-ms/configs"
+	"github.com/eralves01/payment-ms/database"
+	"github.com/eralves01/payment-ms/routes"
 )
 
 func main() {

--- a/processors/credit_card_processor.go
+++ b/processors/credit_card_processor.go
@@ -2,7 +2,8 @@ package processors
 
 import (
 	"fmt"
-	"payment-ms/models"
+
+	"github.com/eralves01/payment-ms/models"
 )
 
 type CreditCardProcessor struct {

--- a/processors/debit_card_processor.go
+++ b/processors/debit_card_processor.go
@@ -2,7 +2,8 @@ package processors
 
 import (
 	"fmt"
-	"payment-ms/models"
+
+	"github.com/eralves01/payment-ms/models"
 )
 
 type DeditCardProcessor struct {

--- a/processors/payment_processor.go
+++ b/processors/payment_processor.go
@@ -1,7 +1,7 @@
 package processors
 
 import (
-	"payment-ms/models"
+	"github.com/eralves01/payment-ms/models"
 )
 
 type PaymentProcessor interface {

--- a/repository/payment_repository.go
+++ b/repository/payment_repository.go
@@ -3,7 +3,8 @@ package repository
 import (
 	"database/sql"
 	"fmt"
-	"payment-ms/models"
+
+	"github.com/eralves01/payment-ms/models"
 )
 
 type PaymentRepository struct {

--- a/repository/user_repository.go
+++ b/repository/user_repository.go
@@ -2,7 +2,8 @@ package repository
 
 import (
 	"database/sql"
-	"payment-ms/models"
+
+	"github.com/eralves01/payment-ms/models"
 )
 
 type UserRepositoryInterface interface {

--- a/routes/router.go
+++ b/routes/router.go
@@ -2,7 +2,8 @@ package routes
 
 import (
 	"net/http"
-	"payment-ms/handlers"
+
+	"github.com/eralves01/payment-ms/handlers"
 
 	"github.com/gorilla/mux"
 )

--- a/services/payment_service.go
+++ b/services/payment_service.go
@@ -1,10 +1,10 @@
 package services
 
 import (
-	"payment-ms/database"
-	"payment-ms/models"
-	"payment-ms/processors"
-	"payment-ms/repository"
+	"github.com/eralves01/payment-ms/database"
+	"github.com/eralves01/payment-ms/models"
+	"github.com/eralves01/payment-ms/processors"
+	"github.com/eralves01/payment-ms/repository"
 )
 
 type PaymentService struct {

--- a/services/user_service.go
+++ b/services/user_service.go
@@ -1,9 +1,9 @@
 package services
 
 import (
-	"payment-ms/database"
-	"payment-ms/models"
-	"payment-ms/repository"
+	"github.com/eralves01/payment-ms/database"
+	"github.com/eralves01/payment-ms/models"
+	"github.com/eralves01/payment-ms/repository"
 )
 
 type UserServices struct{}


### PR DESCRIPTION
Refactoring of the module name from `payment-ms` to `github.com/eralves01/payment-ms`.
This modification was applied to the `go.mod` file and the other files that import the package.